### PR TITLE
Fix write() date range query

### DIFF
--- a/js/WordleData.js
+++ b/js/WordleData.js
@@ -201,14 +201,8 @@ class WordleData {
         if(date) {
           // Based on the above, along with the daily assumption,
           // always replace any record found with a new value.
-          const startDate = new Date(date);
-          startDate.setUTCHours(0, 0, 0, 0);
-          const startOfToday = now.getTime();
-          const endOfToday = (new Date(now).setDate(now.getDate() + 1)).getTime();
-          query.datetime = {
-            $gte: startOfToday,
-            $lt: endOfToday
-          };
+          const datetime = getDateQuery(date);
+          query.datetime = datetime;
         }
         /**
          * If possible, add epoch time


### PR DESCRIPTION
## Summary
- fix undefined `now` variable in WordleData.write()
- compute date range using existing helper

## Testing
- `npm run compile` *(fails: cannot find modules)*
- `npm test` *(fails: main.js not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fa4d91504832ca2c754232281a038